### PR TITLE
Add missing textdomains and some small string corrections

### DIFF
--- a/inc-options/admin_bar.php
+++ b/inc-options/admin_bar.php
@@ -26,7 +26,7 @@ if ( ! isset( $user_roles_names ) ) {
 	<div class="postbox">
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
 		<h3 class="hndle" id="admin_bar_options" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><?php
-			esc_attr_e( 'Admin Bar Back end options', 'adminimize' ); ?></h3>
+			esc_attr_e( 'Admin Bar Back end Options', 'adminimize' ); ?></h3>
 
 		<div class="inside">
 			<br class="clear" />

--- a/inc-options/backend_options.php
+++ b/inc-options/backend_options.php
@@ -224,7 +224,7 @@ if ( ! function_exists( 'add_action' ) ) {
 								</option>
 								<option value="6"<?php if ( $_mw_adminimize_db_redirect === 6 ) {
 									echo ' selected="selected"';
-								} ?>><?php esc_attr_e( 'other Page', 'adminimize' ); ?></option>
+								} ?>><?php esc_attr_e( 'Other Page', 'adminimize' ); ?></option>
 							</select>
 							<textarea style="width: 85%;" class="code" rows="1" cols="60" name="_mw_adminimize_db_redirect_txt" id="_mw_adminimize_db_redirect_txt"><?php
 								echo htmlspecialchars(

--- a/inc-options/minimenu.php
+++ b/inc-options/minimenu.php
@@ -198,7 +198,7 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 				</strong></p>
 				<?php if ( _mw_adminimize_is_active_on_multisite() ) { ?>
 					<p><?php esc_attr_e(
-							'You have to activated the Plugin for your Multisite Network. Your settings works now on all blogs in the network. Please set the settings only in one blog, there you have all active menu items and plugins. If you update the settings then write the plugin new settings in dependence of the blog where you put, save the settings.',
+							'You have activated the Plugin for your Multisite Network. Your settings works now on all blogs in the network. Please set the settings only in one blog, there you have all active menu items and plugins. If you update the settings then write the plugin new settings in dependence of the blog where you put, save the settings.',
 							'adminimize'
 						); ?></p>
 				<?php } ?>

--- a/inc-options/theme_options.php
+++ b/inc-options/theme_options.php
@@ -45,12 +45,12 @@ if ( ! function_exists( 'add_action' ) ) {
 						<thead>
 						<tr class="thead">
 							<th class="num">&nbsp;</th>
-							<th class="num"><?php esc_attr_e( 'User-ID' ) ?></th>
-							<th><?php esc_attr_e( 'Username' ) ?></th>
-							<th><?php esc_attr_e( 'Display name publicly as' ) ?></th>
-							<th><?php esc_attr_e( 'Admin-Color Scheme' ) ?></th>
-							<th><?php esc_attr_e( 'User Level' ) ?></th>
-							<th><?php esc_attr_e( 'Role' ) ?></th>
+							<th class="num"><?php esc_attr_e( 'User-ID', 'adminimize' ) ?></th>
+							<th><?php esc_attr_e( 'Username', 'adminimize' ) ?></th>
+							<th><?php esc_attr_e( 'Display name publicly as', 'adminimize' ) ?></th>
+							<th><?php esc_attr_e( 'Admin-Color Scheme', 'adminimize' ) ?></th>
+							<th><?php esc_attr_e( 'User Level', 'adminimize' ) ?></th>
+							<th><?php esc_attr_e( 'Role', 'adminimize' ) ?></th>
 						</tr>
 						</thead>
 						<tbody id="users" class="list:user user-list">

--- a/inc-options/theme_options.php
+++ b/inc-options/theme_options.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'add_action' ) ) {
 							<th class="num"><?php esc_attr_e( 'User-ID', 'adminimize' ) ?></th>
 							<th><?php esc_attr_e( 'Username', 'adminimize' ) ?></th>
 							<th><?php esc_attr_e( 'Display name publicly as', 'adminimize' ) ?></th>
-							<th><?php esc_attr_e( 'Admin-Color Scheme', 'adminimize' ) ?></th>
+							<th><?php esc_attr_e( 'Admin Color Scheme', 'adminimize' ) ?></th>
 							<th><?php esc_attr_e( 'User Level', 'adminimize' ) ?></th>
 							<th><?php esc_attr_e( 'Role', 'adminimize' ) ?></th>
 						</tr>

--- a/inc-options/write_cp_options.php
+++ b/inc-options/write_cp_options.php
@@ -165,15 +165,15 @@ foreach ( get_post_types( $args ) as $post_type ) {
 					$quickedit_names = array(
 						'<strong>' . esc_attr__( 'Quick Edit Link', 'adminimize' ) . '</strong>',
 						esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Left', 'adminimize' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'All Labels', 'adminimize' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Author' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Password and Private', 'adminimize' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'All Labels', 'adminimize' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Author' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Password and Private', 'adminimize' ),
 						esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Center', 'adminimize' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Categories Title', 'adminimize' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Categories List', 'adminimize' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Categories Title', 'adminimize' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Categories List', 'adminimize' ),
 						esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Right', 'adminimize' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Tags' ),
-						'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Status, Sticky', 'adminimize' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Tags' ),
+						'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Status, Sticky', 'adminimize' ),
 						esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Cancel/Save Button', 'adminimize' ),
 					);
 					$metaboxes_names = array_merge( $metaboxes_names, $quickedit_names );

--- a/inc-options/write_page_options.php
+++ b/inc-options/write_page_options.php
@@ -163,13 +163,13 @@ if ( ! function_exists( 'add_action' ) ) {
 				$quickedit_page_names = array(
 					'<strong>' . esc_attr__( 'Quick Edit Link', 'adminimize' ) . '</strong>',
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Left', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'All Labels', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Date', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Author' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Password and Private', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'All Labels', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Date', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Author' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Password and Private', 'adminimize' ),
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Right', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Parent, Order, Template', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Status', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Parent, Order, Template', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Status', 'adminimize' ),
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Cancel/Save Button', 'adminimize' )
 				);
 				$metaboxes_names_page = array_merge( $metaboxes_names_page, $quickedit_page_names );

--- a/inc-options/write_post_options.php
+++ b/inc-options/write_post_options.php
@@ -163,15 +163,15 @@ if ( ! function_exists( 'add_action' ) ) {
 				$quickedit_names = array(
 					'<strong>' . esc_attr__( 'Quick Edit Link', 'adminimize' ) . '</strong>',
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Left', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'All Labels', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Author' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Password and Private', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'All Labels', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Author' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Password and Private', 'adminimize' ),
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Center', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Categories Title', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Categories List', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Categories Title', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Categories List', 'adminimize' ),
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Inline Edit Right', 'adminimize' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Tags' ),
-					'&emsp;QE &rArr;' . ' ' . esc_attr__( 'Status, Sticky', 'adminimize' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Tags' ),
+					'&emsp;' . esc_attr__( 'QE', 'adminimize' ) . ' &rArr;' . ' ' . esc_attr__( 'Status, Sticky', 'adminimize' ),
 					esc_attr__( 'QE', 'adminimize' ) . ' ' . esc_attr__( 'Cancel/Save Button', 'adminimize' )
 				);
 				$metaboxes_names = array_merge( $metaboxes_names, $quickedit_names );


### PR DESCRIPTION
#### What's Included in this Pull Request
* Added missing textdomains to strings
* Correct some typos in strings
* Merge similar strings to reduce number of needed translations
    Ex: Admin Color Scheme / Admin-Color Scheme
    Chosen the version equal to the one that exists in WP core, for consistency.