### PR TITLE
Add missing empy space between phrases and removed unnecessary html code from strings

### DIFF
--- a/inc-options/backend_options.php
+++ b/inc-options/backend_options.php
@@ -162,7 +162,7 @@ if ( ! function_exists( 'add_action' ) ) {
 						<textarea style="width: 85%;" class="code" rows="1" cols="60" name="_mw_adminimize_advice_txt" id="_mw_adminimize_advice_txt"><?php echo htmlspecialchars(
 								stripslashes( _mw_adminimize_get_option_value( '_mw_adminimize_advice_txt' ) )
 							); ?></textarea><br /><?php esc_attr_e(
-							'In the Footer you can display an  advice for changing the Default-design, (x)HTML is possible.',
+							'In the Footer you can display an advice for changing the Default-design, (x)HTML is possible.',
 							'adminimize'
 						); ?>
 					</td>

--- a/inc-options/minimenu.php
+++ b/inc-options/minimenu.php
@@ -191,6 +191,9 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 						'Please note: The Adminimize settings page ignores the Menu Options below and displays the menu with all entries.',
 						'adminimize'
 					);
+					_e(
+						' '
+					);
 					esc_attr_e(
 						'To view your changes to the menu you need to navigate away from the Adminimize settings page.',
 						'adminimize'

--- a/inc-options/minimenu.php
+++ b/inc-options/minimenu.php
@@ -162,7 +162,9 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 						'http://wordpress.org/extend/plugins/adminimize/',
 						'http://wordpress.org/support/plugin/adminimize'
 					);
-					echo '<br>';
+					_e(
+						'<br>'
+					);
 					printf(
 						__( 'For more hints about the functions and how to\'s with the possibilities of the plugin settings see the <a href="%s">FAQ page</a> on the plugin site.', 'adminimize' ),
 						'https://wordpress.org/plugins/adminimize/faq/'
@@ -192,9 +194,7 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 						'Please note: The Adminimize settings page ignores the Menu Options below and displays the menu with all entries.',
 						'adminimize'
 					);
-					_e(
-						' '
-					);
+					echo ' ';
 					esc_attr_e(
 						'To view your changes to the menu you need to navigate away from the Adminimize settings page.',
 						'adminimize'

--- a/inc-options/minimenu.php
+++ b/inc-options/minimenu.php
@@ -162,8 +162,11 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 						'http://wordpress.org/extend/plugins/adminimize/',
 						'http://wordpress.org/support/plugin/adminimize'
 					);
+					_e(
+						'<br>'
+					);
 					printf(
-						__( '<br>For more hints about the functions and how to\'s with the possibilities of the plugin settings see the <a href="%s">FAQ page</a> on the plugin site.', 'adminimize' ),
+						__( 'For more hints about the functions and how to\'s with the possibilities of the plugin settings see the <a href="%s">FAQ page</a> on the plugin site.', 'adminimize' ),
 						'https://wordpress.org/plugins/adminimize/faq/'
 					);?></li>
 				<li><?php esc_attr_e( 'Report a issue on the development repository:', 'adminimize' ); ?>

--- a/inc-options/minimenu.php
+++ b/inc-options/minimenu.php
@@ -162,9 +162,7 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 						'http://wordpress.org/extend/plugins/adminimize/',
 						'http://wordpress.org/support/plugin/adminimize'
 					);
-					_e(
-						'<br>'
-					);
+					echo '<br>';
 					printf(
 						__( 'For more hints about the functions and how to\'s with the possibilities of the plugin settings see the <a href="%s">FAQ page</a> on the plugin site.', 'adminimize' ),
 						'https://wordpress.org/plugins/adminimize/faq/'

--- a/inc-options/settings_notice.php
+++ b/inc-options/settings_notice.php
@@ -18,6 +18,9 @@ function _mw_adminimize_add_settings_error() {
 			'Please note: The Adminimize settings page ignores the Menu Options below and displays the menu with all entries.',
 			'adminimize'
 		)
+		. __(
+			' '
+		)
 		. esc_attr__(
 			'To view your changes to the menu you need to navigate away from the Adminimize settings page.',
 			'adminimize'

--- a/inc-options/settings_notice.php
+++ b/inc-options/settings_notice.php
@@ -18,9 +18,7 @@ function _mw_adminimize_add_settings_error() {
 			'Please note: The Adminimize settings page ignores the Menu Options below and displays the menu with all entries.',
 			'adminimize'
 		)
-		. __(
-			' '
-		)
+		. ' '
 		. esc_attr__(
 			'To view your changes to the menu you need to navigate away from the Adminimize settings page.',
 			'adminimize'


### PR DESCRIPTION
#### What's Included in this Pull Request
* Add missing spaces between concatenated phrase strings
* Strip out unnecessary html tag from translatable string and moved it to outside hardcoded text
* Removed doublespace

