### PR TITLE
Add missing textdomain

### DIFF
--- a/inc-options/admin_bar.php
+++ b/inc-options/admin_bar.php
@@ -24,8 +24,8 @@ if ( ! isset( $user_roles_names ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
-		<h3 class="hndle" id="admin_bar_options" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><?php
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
+		<h3 class="hndle" id="admin_bar_options" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><?php
 			esc_attr_e( 'Admin Bar Back end Options', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/admin_bar_frontend.php
+++ b/inc-options/admin_bar_frontend.php
@@ -23,8 +23,8 @@ if ( ! isset( $user_roles_names ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
-		<h3 class="hndle" id="admin_bar_frontend_options" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><?php
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
+		<h3 class="hndle" id="admin_bar_frontend_options" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><?php
 			esc_attr_e( 'Admin Bar Front end Options', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/backend_options.php
+++ b/inc-options/backend_options.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'add_action' ) ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="backend_options"><?php esc_attr_e( 'Backend Options', 'adminimize' ); ?></h3>
 		<div class="inside">
 

--- a/inc-options/dashboard_options.php
+++ b/inc-options/dashboard_options.php
@@ -13,7 +13,7 @@ if ( ! function_exists( 'add_action' ) ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="dashboard_options"><?php esc_attr_e( 'Dashboard options', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/deinstall_options.php
+++ b/inc-options/deinstall_options.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="uninstall"><?php esc_attr_e( 'Uninstall Options', 'adminimize' ) ?></h3>
 		<div class="inside">
 

--- a/inc-options/global_options.php
+++ b/inc-options/global_options.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'add_action' ) ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="global_options"><?php esc_attr_e( 'Global options', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/im_export_options.php
+++ b/inc-options/im_export_options.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="import"><?php esc_attr_e( 'Export/Import Options', 'adminimize' ) ?></h3>
 
 		<div class="inside">

--- a/inc-options/links_options.php
+++ b/inc-options/links_options.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'add_action' ) ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="links_options"><?php esc_attr_e( 'Links options', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/menu_options.php
+++ b/inc-options/menu_options.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'add_action' ) ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="config_menu"><?php esc_attr_e( 'Menu Options', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/minimenu.php
+++ b/inc-options/minimenu.php
@@ -21,7 +21,7 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 <br class="clear" />
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div id="minimeu" class="postbox ">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="menu"><?php esc_attr_e( 'MiniMenu', 'adminimize' ) ?></h3>
 
 		<div class="inside">
@@ -140,7 +140,7 @@ if ( _mw_adminimize_is_active_on_multisite() ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div id="about" class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="about-sidebar"><?php esc_attr_e( 'About the plugin', 'adminimize' ) ?></h3>
 
 		<div class="inside">

--- a/inc-options/self_settings.php
+++ b/inc-options/self_settings.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div id="about" class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="self-settings"><?php esc_attr_e( 'Plugin Settings', 'adminimize' ) ?></h3>
 
 		<div class="inside">

--- a/inc-options/theme_options.php
+++ b/inc-options/theme_options.php
@@ -11,8 +11,8 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
-		<h3 class="hndle" id="set_theme" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><?php
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
+		<h3 class="hndle" id="set_theme" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><?php
 			esc_attr_e( 'Set Theme', 'adminimize' ) ?></h3>
 
 		<div class="inside">

--- a/inc-options/widget_options.php
+++ b/inc-options/widget_options.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="widget_options"><?php esc_attr_e( 'Widgets', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/wp_nav_menu_options.php
+++ b/inc-options/wp_nav_menu_options.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="nav_menu_options"><?php esc_attr_e( 'WP Nav Menu', 'adminimize' ); ?></h3>
 
 		<div class="inside">

--- a/inc-options/write_cp_options.php
+++ b/inc-options/write_cp_options.php
@@ -17,7 +17,7 @@ foreach ( get_post_types( $args ) as $post_type ) {
 
 	<div id="poststuff" class="ui-sortable meta-box-sortables">
 		<div class="postbox">
-			<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+			<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 			<h3 class="hndle" id="config_edit_<?php echo $post_type; ?>">
 				<?php esc_attr_e( 'Write options', 'adminimize' );
 				echo ' - ' . $post_type_object->label; ?>

--- a/inc-options/write_page_options.php
+++ b/inc-options/write_page_options.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'add_action' ) ) {
 ?>
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
 		<h3 class="hndle" id="config_edit_page"><?php esc_attr_e( 'Write options - Page', 'adminimize' ); ?></h3>
 		<div class="inside">
 			<br class="clear" />

--- a/inc-options/write_post_options.php
+++ b/inc-options/write_post_options.php
@@ -12,8 +12,8 @@ if ( ! function_exists( 'add_action' ) ) {
 
 <div id="poststuff" class="ui-sortable meta-box-sortables">
 	<div class="postbox">
-		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><br /></div>
-		<h3 class="hndle" id="config_edit_post" title="<?php esc_attr_e( 'Click to toggle' ); ?>"><?php
+		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><br /></div>
+		<h3 class="hndle" id="config_edit_post" title="<?php esc_attr_e( 'Click to toggle', 'adminimize' ); ?>"><?php
 			esc_attr_e( 'Write options - Post', 'adminimize' ); ?></h3>
 
 		<div class="inside">


### PR DESCRIPTION
Thanks for contributing to Adminimize &mdash; you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include appropriate inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters
- In case you added or changed assets, please make sure you did this in the resources/ folder.
- If you Grunt installed, please run `grunt pre-commit` before committing your changes.
-->

This pull request fixes issue #.

#### What's Included in this Pull Request
* Added missing textodomains to 22 entries of "Click to toggle" string.
* 
* 

