### PR TITLE
Fix array to string conversion in _mw_adminimize_get_duplicate

### DIFF
--- a/inc-setup/helping_hands.php
+++ b/inc-setup/helping_hands.php
@@ -115,7 +115,7 @@ function _mw_adminimize_debug( $data, $description = '' ) {
  */
 function _mw_adminimize_get_duplicate( $array ) {
 
-	return array_unique( array_diff_assoc( $array, array_unique( $array ) ) );
+  return array_unique( array_map('unserialize',array_diff_assoc( array_map('serialize',$array), array_map('serialize',array_unique( $array, SORT_REGULAR ) ) ) ), SORT_REGULAR );
 }
 
 /**

--- a/inc-setup/helping_hands.php
+++ b/inc-setup/helping_hands.php
@@ -115,7 +115,7 @@ function _mw_adminimize_debug( $data, $description = '' ) {
  */
 function _mw_adminimize_get_duplicate( $array ) {
 
-  return array_unique( array_map('unserialize',array_diff_assoc( array_map('serialize',$array), array_map('serialize',array_unique( $array, SORT_REGULAR ) ) ) ), SORT_REGULAR );
+  return array_unique( array_map( 'unserialize', array_diff_assoc( array_map( 'serialize', $array), array_map( 'serialize', array_unique( $array, SORT_REGULAR ) ) ) ), SORT_REGULAR );
 }
 
 /**


### PR DESCRIPTION
`_mw_adminimize_get_duplicate` was reporting many array to string conversion errors with Wordpress running in debug mode as array_unique and array_diff_assoc only check a single array dimension. Fixed by serializing array using array_map before array_unique and array_diff_assoc and unserializing afterwards.

#### What's Included in this Pull Request
* Change to `_mw_adminimize_get_duplicate` in `inc-setup\helping-hands.php` to avoid array to string conversion