### PR TITLE
Followup PR: Tabs and Code Coverage exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ stages:
 - test
 
 php:
-- 7.2
-- 7.1
+- 7.0
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ stages:
 - quality
 - test
 
+php:
+- 7.2
+- 7.1
+
 jobs:
   allow_failures:
   - env: STAGE=quality
@@ -35,7 +39,7 @@ cache:
 
 branches:
   only:
-    refactor
+  - refactor
 
 before_install:
 # disable xDebug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,20 @@ jobs:
   - env: STAGE=quality
   - php: nightly
   include:
-  # PHPCS ##################
   - stage: quality
     env: STAGE=quality
     php: '7.1'
     script: vendor/bin/phpcs
-
-  # PHPUnit ################
   - stage: test
+    env: STAGE=test
     php: '7.1'
     script: vendor/bin/phpunit
   - stage: test
+    env: STAGE=test
     php: '7.2'
     script: vendor/bin/phpunit
   - stage: test
+    env: STAGE=test
     php: nightly
     script: vendor/bin/phpunit
 

--- a/assets/js/adminimize.js
+++ b/assets/js/adminimize.js
@@ -4,16 +4,23 @@
  *
  * @version 2015-12-20
  */
-jQuery(document).ready(function ( $ ) {
+jQuery(document).ready(function ($) {
     'use strict';
-
-    $('#nav-tabs').tabs();
 
     $('a.nav-tab').click(function () {
         $('a.nav-tab').each(function () {
             $(this).removeClass('nav-tab-active');
         });
+
+        $('div.tab-content').each(function () {
+            $(this).addClass('hidden');
+        });
+
+        var tabKey = $(this).data('tab');
+        $('div#tab-' + tabKey).removeClass('hidden');
         $(this).addClass('nav-tab-active');
+
+        return false;
     });
 
     $('thead input:checkbox').change(function () {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
 			<exclude>
 				<directory>tests</directory>
 				<directory>vendor</directory>
+				<directory>src/Templates</directory>
 			</exclude>
 		</whitelist>
 	</filter>

--- a/src/Settings/View/View.php
+++ b/src/Settings/View/View.php
@@ -135,16 +135,14 @@ class View implements ViewInterface
 
         wp_register_script(
             'adminimize_admin',
-            plugins_url('../../../assets/js/adminimize.js', __FILE__),
-            ['jquery', 'jquery-ui-tabs']
+            plugins_url('../../../assets/js/adminimize.js', __FILE__), ['jquery']
         );
 
         wp_enqueue_script('adminimize_admin');
 
         wp_register_style(
             'adminimize_admin',
-            plugins_url('../../../assets/css/style.css', __FILE__),
-            []
+            plugins_url('../../../assets/css/style.css', __FILE__), []
         );
 
         wp_enqueue_style('adminimize_admin');

--- a/src/Settings/View/View.php
+++ b/src/Settings/View/View.php
@@ -135,14 +135,16 @@ class View implements ViewInterface
 
         wp_register_script(
             'adminimize_admin',
-            plugins_url('../../../assets/js/adminimize.js', __FILE__), ['jquery']
+            plugins_url('../../../assets/js/adminimize.js', __FILE__),
+            ['jquery']
         );
 
         wp_enqueue_script('adminimize_admin');
 
         wp_register_style(
             'adminimize_admin',
-            plugins_url('../../../assets/css/style.css', __FILE__), []
+            plugins_url('../../../assets/css/style.css', __FILE__),
+            []
         );
 
         wp_enqueue_style('adminimize_admin');

--- a/src/Templates/SettingsPage.php
+++ b/src/Templates/SettingsPage.php
@@ -3,18 +3,20 @@
 <div class="wrap">
     <h1><?= esc_attr($this->pageTitle); ?></h1>
 
-    <h2 class="nav-tab-wrapper">
-        <?php foreach ((array)$this->tabs as $key => $tab) : ?>
-            <a class="nav-tab <?php echo $key === 0 ? 'nav-tab-active' : ''; ?>"
-                href="#tab-<?= esc_attr($key); ?>">
-                <?= esc_html($tab->title()); ?>
-            </a>
-        <?php endforeach; ?>
-    </h2>
+    <div class="nav-tabs">
+        <h2 class="nav-tab-wrapper">
+            <?php foreach ((array)$this->tabs as $key => $tab) : ?>
+                <a class="nav-tab <?php echo $key === 0 ? 'nav-tab-active' : ''; ?>"
+                    href="#tab-<?= esc_attr($key); ?>" data-tab="<?= esc_attr($key); ?>">
+                    <?= esc_html($tab->title()); ?>
+                </a>
+            <?php endforeach; ?>
+        </h2>
 
-    <?php foreach ((array)$this->tabs as $key => $tab) : ?>
-        <div id="tab-<?= esc_attr($key) ?>">
-            <?= esc_attr($tab->render()) ?>
-        </div>
-    <?php endforeach; ?>
+        <?php foreach ((array)$this->tabs as $key => $tab) : ?>
+            <div id="tab-<?= esc_attr($key) ?>" class="tab-content <?php echo $key !== 0 ? 'hidden' : ''; ?>"">
+                <?= esc_attr($tab->render()) ?>
+            </div>
+        <?php endforeach; ?>
+    </div>
 </div>

--- a/src/Templates/SettingsPage.php
+++ b/src/Templates/SettingsPage.php
@@ -3,24 +3,18 @@
 <div class="wrap">
     <h1><?= esc_attr($this->pageTitle); ?></h1>
 
-    <div id="nav-tabs">
-        <h2 class="nav-tab-wrapper">
-            <ul>
-                <?php foreach ((array)$this->tabs as $key => $tab) : ?>
-                    <li>
-                        <a class="nav-tab <?php echo $key === 0 ? 'nav-tab-active' : ''; ?>"
-                            href="#tab-<?= esc_attr($key); ?>">
-                            <?= esc_html($tab->title()); ?>
-                        </a>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        </h2>
-
+    <h2 class="nav-tab-wrapper">
         <?php foreach ((array)$this->tabs as $key => $tab) : ?>
-            <div id="tab-<?php echo esc_attr($key) ?>">
-                <?= esc_attr($tab->render()) ?>
-            </div>
+            <a class="nav-tab <?php echo $key === 0 ? 'nav-tab-active' : ''; ?>"
+                href="#tab-<?= esc_attr($key); ?>">
+                <?= esc_html($tab->title()); ?>
+            </a>
         <?php endforeach; ?>
-    </div>
+    </h2>
+
+    <?php foreach ((array)$this->tabs as $key => $tab) : ?>
+        <div id="tab-<?= esc_attr($key) ?>">
+            <?= esc_attr($tab->render()) ?>
+        </div>
+    <?php endforeach; ?>
 </div>

--- a/tests/Unit/AbstractTestCase.php
+++ b/tests/Unit/AbstractTestCase.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class AbstractTestCase extends TestCase
 {
-	/**
+    /**
 	 * Sets up the environment.
 	 *
 	 * @return void
@@ -31,5 +31,4 @@ abstract class AbstractTestCase extends TestCase
 		Monkey\tearDown();
 		parent::tearDown();
 	}
-
 }

--- a/tests/Unit/AdminimizeTest.php
+++ b/tests/Unit/AdminimizeTest.php
@@ -11,7 +11,7 @@ use Adminimize\Plugin;
  */
 class AdminimizeTest extends AbstractTestCase
 {
-	public function test_basic()
+	public function testBasicInstantiation()
     {
 		$plugin = new Plugin(__DIR__);
 		static::assertInstanceOf(Plugin::class, $plugin);

--- a/tests/Unit/Settings/SettingsRepositoryTest.php
+++ b/tests/Unit/Settings/SettingsRepositoryTest.php
@@ -35,10 +35,12 @@ class SettingsRepositoryTest extends AbstractTestCase
     {
         parent::setUp();
 
-        Functions\when('add_option')->justReturn(null);
-        Functions\when('update_option')->justReturn(true);
-        Functions\when('wp_cache_get')->justReturn(false);
-        Functions\when('wp_cache_set')->justReturn(true);
+        Functions\stubs([
+            'add_option' => '__return_null',
+            'update_option' => true,
+            'wp_cache_get' => false,
+            'wp_cache_set' => true,
+        ]);
 
         Functions\when('delete_option')->alias(function ($key) {
             unset($this->actualData[$key]);


### PR DESCRIPTION
<!-- Thanks for contributing to Adminimize &mdash; you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include appropriate inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters
- In case you added or changed assets, please make sure you did this in the resources/ folder.
- If you Grunt installed, please run `grunt pre-commit` before committing your changes.
-->

@bueltge Like we discussed in the other PR, the tabs needed to fit the WordPress design. In order to do that, I implemented a simple tab solution in jQuery and removed the jQueryUI dependency. jQueryUI tabs required the use of `ul/ol` and list items - otherwise it wouldn't have worked. Since the requirement was simple enough, the jQuery solution should be good to go.

For the Code Coverage issue and the failing tests, adding the exclusion in `phpunit.xml.dist` as discussed fixes the problem.
