### PR TITLE
 Some plugins create a title that contains an array, we create an emp…

### DIFF
--- a/inc-setup/dashboard.php
+++ b/inc-setup/dashboard.php
@@ -151,7 +151,13 @@ function _mw_adminimize_get_dashboard_widgets() {
 		foreach ( (array) $datas as $priority => $data ) {
 			foreach ( (array) $data as $widget => $value ) {
 
+
 				if ( ! isset( $value['title'])) {
+					$value['title'] = '';
+				}
+
+				// Some plugins create a title that contains an array, we create an empty string to prevent an error in strip_tags
+				if (is_array ( $value['title'])) {
 					$value['title'] = '';
 				}
 


### PR DESCRIPTION
 Some plugins create a title that contains an array, we create an empty string to prevent an error in strip_tags

This pull request fixes issue #153 .
