### PR TITLE
Add deploy workflow to the wp repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,9 @@ composer.json       export-ignore
 package.json        export-ignore
 phpunit.xml.dist    export-ignore
 .travis.yml         export-ignore
+.github/            export-ignore
+.gitpod.dockerfile  export-ignore
+.gitpod.yml         export-ignore
+.editorconfig       export-ignore
+CHANGELOG.md        export-ignore
+phpcs.xml           export-ignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to WordPress.org Repository
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  deploy_to_wp_repository:
+    name: Deploy to WP.org
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
+    - name: Upload release asset
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: ${{ github.workspace }}/${{ github.event.repository.name }}.zip


### PR DESCRIPTION
Trigger a deploy action when creating a new release on Github, to automate the process to the SVN repository automatically.

Also update list of files ignored from export to prevent unnecessary files sent to the production.