### PR TITLE
v1.11.14

### DIFF
--- a/adminimize.php
+++ b/adminimize.php
@@ -7,7 +7,7 @@
  * Description: Visually compresses the administrative meta-boxes so that more admin page content can be initially seen. The plugin that lets you hide 'unnecessary' items from the WordPress administration menu, for all roles of your install. You can also hide post meta controls on the edit-area to simplify the interface. It is possible to simplify the admin in different for all roles.
  * Author:      WP Media
  * Author URI:  https://wp-media.me
- * Version:     1.11.14-rc1
+ * Version:     1.11.14
  * License:     GPLv2+
  *
  * Php Version 5.6

--- a/adminimize.php
+++ b/adminimize.php
@@ -7,7 +7,7 @@
  * Description: Visually compresses the administrative meta-boxes so that more admin page content can be initially seen. The plugin that lets you hide 'unnecessary' items from the WordPress administration menu, for all roles of your install. You can also hide post meta controls on the edit-area to simplify the interface. It is possible to simplify the admin in different for all roles.
  * Author:      WP Media
  * Author URI:  https://wp-media.me
- * Version:     1.11.13
+ * Version:     1.11.14-rc1
  * License:     GPLv2+
  *
  * Php Version 5.6

--- a/inc-setup/helping_hands.php
+++ b/inc-setup/helping_hands.php
@@ -193,10 +193,14 @@ function _mw_adminimize_check_page_access( $slug ) {
         if ( empty( $slug_query ) && ! empty( $request_query ) ) {
             wp_parse_str( html_entity_decode( $request_query ), $request_params );
 
-            // If request has post_type, but slug doesn't, we're on the posts section
-            if ( isset( $request_params['post_type'] ) && 'post' !== $request_params['post_type'] ) {
-                return false;
-            }
+			// Only treat `post_type` as a differentiator on core post list / add-new screens.
+			if (
+				in_array( $slug_path, array( 'edit.php', 'post-new.php' ), true )
+				&& isset( $request_params['post_type'] )
+				&& 'post' !== $request_params['post_type']
+			) {
+				return false;
+			}
 
             // Request is for default post type or doesn't specify post_type - block it
             add_action( 'load-' . $slug, '_mw_adminimize_block_page_access' );

--- a/inc-setup/helping_hands.php
+++ b/inc-setup/helping_hands.php
@@ -178,17 +178,55 @@ function _mw_adminimize_check_page_access( $slug ) {
 		return false;
 	}
 
-	// URI without query parameter, like WP core edit.php.
-	if ( ! isset( $uri['query'] ) && strpos( $uri['path'], $slug ) !== false ) {
-		add_action( 'load-' . $slug, '_mw_adminimize_block_page_access' );
-		return true;
-	}
+	$slug_parts = wp_parse_url( $slug );
+	$slug_path  = isset( $slug_parts['path'] ) ? $slug_parts['path'] : $slug;
+	$slug_query = isset( $slug_parts['query'] ) ? $slug_parts['query'] : '';
+	$request_query = isset( $uri['query'] ) ? $uri['query'] : '';
 
-	// URL is equal the slug of WP menu.
-	if ( $slug === $url ) {
-		add_action( 'load-' . basename( $uri['path'] ), '_mw_adminimize_block_page_access' );
-		return true;
-	}
+    if ( strpos( $uri['path'], $slug_path ) !== false ) {
+        if ( empty( $slug_query ) && empty( $request_query ) ) {
+            add_action( 'load-' . $slug, '_mw_adminimize_block_page_access' );
+            return true;
+        }
+
+        // Slug has no query, but request does
+        if ( empty( $slug_query ) && ! empty( $request_query ) ) {
+            wp_parse_str( html_entity_decode( $request_query ), $request_params );
+
+            // If request has post_type, but slug doesn't, we're on the posts section
+            if ( isset( $request_params['post_type'] ) && 'post' !== $request_params['post_type'] ) {
+                return false;
+            }
+
+            // Request is for default post type or doesn't specify post_type - block it
+            add_action( 'load-' . $slug, '_mw_adminimize_block_page_access' );
+            return true;
+        }
+
+        // Both have query params - verify slug params match in request
+        if ( $slug_query && $request_query ) {
+            wp_parse_str( html_entity_decode( $slug_query ), $slug_params );
+            wp_parse_str( html_entity_decode( $request_query ), $request_params );
+
+            // Check if all slug params are present in request with matching values
+            $all_match = true;
+            foreach ( $slug_params as $key => $value ) {
+                if ( ! isset( $request_params[ $key ] ) || $request_params[ $key ] !== $value ) {
+                    $all_match = false;
+                    break;
+                }
+            }
+
+            if ( $all_match ) {
+                add_action( 'load-' . basename( $uri['path'] ), '_mw_adminimize_block_page_access' );
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+	return false;
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wp_media, Bueltge, inpsyde
 Tags: customization, administration
 Requires at least: 4.0
 Tested up to: 7.0
-Stable tag: 1.11.13
+Stable tag: 1.11.14
 
 Adminimize that lets you hide 'unnecessary' items from the WordPress backend
 
@@ -37,6 +37,9 @@ Use the installer via back-end of your install or ...
 4. Administrator can go to `Settings` > `Adminimize` menu and configure the plugin (Menu, Sub-menu, Meta boxes, ...)
 
 == Changelog ==
+= 1.11.14 (2026-06-10) =
+* Improve pages access blocking
+
 = 1.11.13 (2026-06-02) =
 * Revert change blocking unexpected pages
 


### PR DESCRIPTION
Improve pages access blocking logic to take into account the specificity of `edit.php` being the slug for posts, while other post types use a `post_type` parameter to differenciate between them. This is a legacy of early WordPress that was never changed.